### PR TITLE
Mercury#republish

### DIFF
--- a/lib/mercury/fake/queued_message.rb
+++ b/lib/mercury/fake/queued_message.rb
@@ -9,7 +9,7 @@ class Mercury
 
       def initialize(queue, msg, tag, headers, is_ackable)
         metadata = Metadata.new(tag, headers, proc{queue.ack_or_reject_message(self)}, proc{queue.nack(self)})
-        @received_msg = ReceivedMessage.new(msg, metadata, is_ackable: is_ackable)
+        @received_msg = ReceivedMessage.new(msg, metadata, work_queue_name: is_ackable ? queue.worker : nil)
         @headers = headers
         @delivered = false
       end

--- a/lib/mercury/mercury.rb
+++ b/lib/mercury/mercury.rb
@@ -5,6 +5,9 @@ require 'mercury/received_message'
 require 'logatron/logatron'
 
 class Mercury
+  ORIGINAL_TAG_HEADER = 'Original-Tag'.freeze
+  REPUBLISH_COUNT_HEADER = 'Republish-Count'.freeze
+
   attr_reader :amqp, :channel, :logger
 
   def self.open(logger: Logatron, **kws, &k)
@@ -63,8 +66,6 @@ class Mercury
       publish_internal(exchange, msg, tag, headers, &k)
     end
   end
-
-  ORIGINAL_TAG_HEADER = 'Original-Tag'.freeze
 
   # Places a copy of the message at the back of the queue, then acks
   # the original message.
@@ -156,6 +157,8 @@ class Mercury
 
   private
 
+  LOGATRAON_MSG_ID_HEADER = 'X-Ascent-Log-Id'.freeze
+
   # In AMQP, queue consumers ack requests after handling them. Unacked messages
   # are automatically returned to the queue, guaranteeing they are eventually handled.
   # Services often ack one request while publishing related messages. Ideally, these
@@ -207,8 +210,6 @@ class Mercury
       @confirm_handlers.delete(tag).call
     end
   end
-
-  LOGATRAON_MSG_ID_HEADER = 'X-Ascent-Log-Id'.freeze
 
   def make_received_message(payload, metadata, work_queue_name: nil)
     msg = ReceivedMessage.new(read(payload), metadata, work_queue_name: work_queue_name)
@@ -315,8 +316,6 @@ class Mercury
       k.call(queue)
     end
   end
-
-  REPUBLISH_COUNT_HEADER = 'Republish-Count'.freeze
 
   # @param msg [Mercury::ReceivedMessage]
   # @return [Hash] the headers with republish count incremented

--- a/lib/mercury/monadic.rb
+++ b/lib/mercury/monadic.rb
@@ -25,6 +25,7 @@ class Mercury
     end
 
     wrap(:publish)
+    wrap(:republish)
     wrap(:start_listener)
     wrap(:start_worker)
     wrap(:delete_source)

--- a/mercury_amqp.gemspec
+++ b/mercury_amqp.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bunny', '~> 2.1'
   spec.add_runtime_dependency 'binding_of_caller', '~> 0.7'
   spec.add_runtime_dependency 'logatron', '~> 0'
+  spec.add_runtime_dependency 'activesupport', '~> 4.0'
 end

--- a/spec/lib/mercury/received_message_spec.rb
+++ b/spec/lib/mercury/received_message_spec.rb
@@ -56,11 +56,11 @@ describe Mercury::ReceivedMessage do
   end
 
   def make_actionable
-    Mercury::ReceivedMessage.new('hello', make_metadata, is_ackable: true)
+    Mercury::ReceivedMessage.new('hello', make_metadata, work_queue_name: 'foo')
   end
 
   def make_non_actionable
-    Mercury::ReceivedMessage.new('hello', make_metadata, is_ackable: false)
+    Mercury::ReceivedMessage.new('hello', make_metadata, work_queue_name: nil)
   end
 
   def make_metadata


### PR DESCRIPTION
Added method to republish a message.

Tue May 10 12:00:09 EDT 2016
Finished in 9.13 seconds (files took 0.26981 seconds to load)
118 examples, 0 failures

Note: The `Mercury::Fake` changes appear first in the PR diff; I suggest reviewing them last.

I will run rubocop on a separate PR.
