### PR TITLE
[AR-2594] Set logatron site

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ logatron's request ID (`Logatron.msg_id`) through the AMQP header
 logs associated with a particular incoming request, even though the
 log entries may be scattered across various services.
 
+Mercury also sets the current site from the message as the Logatron site
+('Logatron.site'). This value is set in differently in the different messages in our
+system, which are currently hard-coded into Mercury.
+
 ### Thread safety
 
 Mercury is not threadsafe. All calls to a particular instance must be made from the

--- a/lib/mercury/mercury.rb
+++ b/lib/mercury/mercury.rb
@@ -216,7 +216,16 @@ class Mercury
   def make_received_message(payload, metadata, work_queue_name: nil)
     msg = ReceivedMessage.new(read(payload), metadata, self, work_queue_name: work_queue_name)
     Logatron.msg_id = msg.headers[LOGATRAON_MSG_ID_HEADER]
+    Logatron.site = get_message_site(msg.content)
     msg
+  end
+
+  def get_message_site(content)
+    content['organization'] ||
+      content['customer'] ||
+      content['site'] ||
+      content.fetch('request', {})['customer'] ||
+      '-'
   end
 
   def existence_check(k, &check)

--- a/spec/lib/mercury/cps_spec.rb
+++ b/spec/lib/mercury/cps_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'mercury/cps'
 
-Cps = Mercury::Cps
-
 describe Cps do
   include Cps::Methods
 

--- a/spec/lib/mercury/monadic_spec.rb
+++ b/spec/lib/mercury/monadic_spec.rb
@@ -182,6 +182,58 @@ describe Mercury::Monadic do
     end
   end
 
+  shared_examples 'a message with a site' do
+    it 'sets the current site in logatron' do
+      test_with_mercury do |m|
+        msgs = []
+        seql do
+          and_then { m.start_listener(source, &msgs.method(:push)) }
+          and_then { m.publish(source, site_msg) }
+          and_then { wait_until { msgs.size == 1 } }
+          and_lift { expect(Logatron.site).to eql current_site }
+        end
+      end
+    end
+  end
+
+  context 'when a message sets the current site in the organization field' do
+    let(:current_site) { 'site1' }
+    let(:site_msg) { {'organization' => current_site} }
+    include_examples 'a message with a site'
+  end
+
+  context 'when a message sets the current site in the customer field' do
+    let(:current_site) { 'site2' }
+    let(:site_msg) { {'customer' => current_site} }
+    include_examples 'a message with a site'
+  end
+
+  context 'when a message sets the current site in the site field' do
+    let(:current_site) { 'site3' }
+    let(:site_msg) { {'site' => current_site} }
+    include_examples 'a message with a site'
+  end
+
+  context 'when a message sets the current site in the request->customer field' do
+    let(:current_site) { 'site4' }
+    let(:site_msg) { {'request' => { 'customer' => current_site}} }
+    include_examples 'a message with a site'
+  end
+
+  context 'when a message does not set the current site' do
+    it 'sets the current site to blank' do
+      test_with_mercury do |m|
+        msgs = []
+        seql do
+          and_then { m.start_listener(source, &msgs.method(:push)) }
+          and_then { m.publish(source, {'a' => 1}) }
+          and_then { wait_until { msgs.size == 1 } }
+          and_lift { expect(Logatron.site).to eql '-' }
+        end
+      end
+    end
+  end
+
   itt 'uses AMQP-style tag filters' do
     test_with_mercury do |m|
       successes = []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ def test_with_mercury_cps(sources, queues, **kws, &block)
   end
 end
 
+Logatron.configuration.logger = Logger.new(File::NULL)
+
 module MercuryFakeSpec
   def self.included(base)
     base.extend(ClassMethods)


### PR DESCRIPTION
The system currently does not have a unified way of passing the current site around, but all the different messages are defined in one spot, which are all covered by this PR.