### PR TITLE
[AR-2594] Remove Logatron; allow Mercury::Sync.publish to set headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,6 @@ arbitrary encoding. The receiving client receives the exact same
 string as the message content (assuming the serialized message fails to
 parse as JSON).
 
-### Logatron integration
-
-Mercury depends on the
-[`logatron`][logatron] gem and propagates
-logatron's request ID (`Logatron.msg_id`) through the AMQP header
-`X-Ascent-Log-Id`. This enables a log aggregation service to find the
-logs associated with a particular incoming request, even though the
-log entries may be scattered across various services.
-
 ### Thread safety
 
 Mercury is not threadsafe. All calls to a particular instance must be made from the
@@ -423,7 +414,6 @@ is being intentionally ignored.
 
 [amqp]: https://github.com/ruby-amqp/amqp
 [em]: https://github.com/eventmachine/eventmachine
-[logatron]: https://github.com/indigobio/logatron
 [em_defer]: http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine.defer
 [fiber_defer]: https://github.com/indigobio/abstractivator/blob/master/lib/abstractivator/fiber_defer.rb
 [default_exchange]: https://www.rabbitmq.com/tutorials/amqp-concepts.html

--- a/lib/mercury/sync.rb
+++ b/lib/mercury/sync.rb
@@ -4,14 +4,14 @@ require 'bunny'
 class Mercury
   class Sync
     class << self
-      def publish(source_name, msg, tag: '', amqp_opts: {}, wait_for_publisher_confirms: true)
+      def publish(source_name, msg, tag: '', headers: {}, amqp_opts: {}, wait_for_publisher_confirms: true)
         conn = Bunny.new(amqp_opts)
         conn.start
         ch = conn.create_channel
 
         ch.confirm_select if wait_for_publisher_confirms # see http://rubybunny.info/articles/extensions.html and Mercury#enable_publisher_confirms
         ex = ch.topic(source_name, Mercury.source_opts)
-        ex.publish(WireSerializer.new.write(msg), **Mercury.publish_opts(tag, {}))
+        ex.publish(WireSerializer.new.write(msg), **Mercury.publish_opts(tag, headers))
         if wait_for_publisher_confirms
           ch.wait_for_confirms or raise 'failed to confirm publication'
         end

--- a/mercury_amqp.gemspec
+++ b/mercury_amqp.gemspec
@@ -29,6 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'amqp', '~> 1.5'
   spec.add_runtime_dependency 'bunny', '~> 2.1'
   spec.add_runtime_dependency 'binding_of_caller', '~> 0.7'
-  spec.add_runtime_dependency 'logatron', '~> 0'
   spec.add_runtime_dependency 'activesupport', '> 4.0', '< 6.0'
 end

--- a/spec/lib/mercury/cps_spec.rb
+++ b/spec/lib/mercury/cps_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'mercury/cps'
 
-Cps = Mercury::Cps
-
 describe Cps do
   include Cps::Methods
 

--- a/spec/lib/mercury/sync_spec.rb
+++ b/spec/lib/mercury/sync_spec.rb
@@ -6,6 +6,7 @@ describe Mercury::Sync do
   include Cps::Methods
   let!(:source) { 'test-exchange1' }
   let!(:queue) { 'test-queue1' }
+  let(:headers) { {'X-Domain-Variable' => 'value'} }
   describe '::publish' do
     %w{with without}.each do |w|
       it "publishes synchronously (#{w} publisher confirms)" do
@@ -15,11 +16,12 @@ describe Mercury::Sync do
         test_with_mercury(wait_for_publisher_confirms: use_publisher_confirms) do |m|
           seql do
             and_then { m.start_listener(source, received.method(:push)) }
-            and_lift { Mercury::Sync.publish(source, sent) }
+            and_lift { Mercury::Sync.publish(source, sent, headers: headers) }
             and_then { wait_until { received.any? } }
             and_lift do
               expect(received.size).to eql 1
               expect(received[0].content).to eql sent
+              expect(received[0].headers).to eql headers
             end
           end
         end


### PR DESCRIPTION
Also cleaned up test output.